### PR TITLE
[3.3] Update bolt/filesystem minimum to ^2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "bolt/filesystem": "^2.0",
+        "bolt/filesystem": "^2.3",
         "contao/imagine-svg": "~0.1.2",
         "doctrine/cache": "^1.4",
         "ext-gd": "*",


### PR DESCRIPTION
Related to changes from https://github.com/bolt/filesystem/pull/52

I have sent to 3.x as we'll tidy up, and branch `3.3` when we're all but ready to tag 3.3.0