### PR TITLE
Remove exception silencing and fix return type

### DIFF
--- a/src/Creator.php
+++ b/src/Creator.php
@@ -153,11 +153,7 @@ class Creator implements CreatorInterface
             }
         }
 
-        try {
-            $img = ImageResource::createFromString($transaction->getSrcImage()->read());
-        } catch (Exception $e) {
-            return false;
-        }
+        $img = ImageResource::createFromString($transaction->getSrcImage()->read());
 
         $target = clone $transaction->getTarget();
 


### PR DESCRIPTION
This method is expected to return a string anyway.

Fixes #36.